### PR TITLE
Can activationEvents change to wildcard (*) ?

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "Other"
   ],
   "activationEvents": [
-    "onLanguage:markdown"
+    "*"
   ],
   "main": "./out/src/extension",
   "contributes": {


### PR DESCRIPTION
Dear timmyreilly,
I installed TypewriterNoises plugin on my VSCode, It is very nice. 

However, It only can start when I type on markdown file, as activationEvents is onLanguage:markdown. If it is can start on typing anything, I think it will be more user-friendly. 

Thank you !
